### PR TITLE
Added deviccetree availability dependency

### DIFF
--- a/drivers/sensor/honeywell/hpma115/Kconfig
+++ b/drivers/sensor/honeywell/hpma115/Kconfig
@@ -3,6 +3,6 @@
 config HPMA115
 	bool "HPMA115 peripheral"
 	default y
-	depends on UART_INTERRUPT_DRIVEN
+	depends on DT_HAS_HONEYWELL_HPMA115_ENABLED && UART_INTERRUPT_DRIVEN
 	help
 	  Enable hpma115 sensor


### PR DESCRIPTION
Added dependency in Kconfig of the HPMA115 to remove instanciation at compilation without hpma115 present in the devicetree.